### PR TITLE
Remove remaining unsafeFlags

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,8 @@ let swiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("ForwardTrailingClosures"),
     .enableUpcomingFeature("ImplicitOpenExistentials"),
-    .enableUpcomingFeature("StrictConcurrency"),
-    .unsafeFlags(["-warn-concurrency", "-enable-actor-data-race-checks"])
+    .enableUpcomingFeature("StrictConcurrency")//,
+//    .unsafeFlags(["-warn-concurrency", "-enable-actor-data-race-checks"])
 ]
 
 let package = Package(


### PR DESCRIPTION
 Current package throws "The package product 'DocScanner' cannot be used as a dependency of this target because it uses unsafe build flags".